### PR TITLE
Fix music not changing properly when returning to main menu

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -192,7 +192,7 @@ init -1 python hide:
 
     ## Music that is played while the user is at the main menu.
 
-    config.main_menu_music = True
+    config.main_menu_music = "music/Ode To Joy.ogg"
 
 
     #########################################


### PR DESCRIPTION
When returning to the main menu from an in-game scene, the music from that scene continues to play in the main menu. This change should transition the music back to the main menu music without affecting the splash screen's music.